### PR TITLE
Switch to rectified flow

### DIFF
--- a/dit_videos/denoiser.py
+++ b/dit_videos/denoiser.py
@@ -38,6 +38,11 @@ class Denoiser(nn.Module):
         return self.core_model(*args, **kwargs)
     
     def predict(self, sample, t, embeds):
+        """
+        :param sample: Pixel values for noisy sample
+        :param t: Timestep as iterable of floats
+        :param embeds: hidden states from text encoder
+        """
         return self.core_model.predict(sample, t, embeds)
     
     @torch.no_grad()

--- a/dit_videos/pokemon_data.py
+++ b/dit_videos/pokemon_data.py
@@ -1,0 +1,72 @@
+from torch.utils.data import DataLoader, Dataset
+from datasets import load_dataset
+from torchvision import transforms
+import einops as eo
+import random
+import torch
+
+"""
+Toy dataset using pokemon from BLIP
+"""
+
+class VideoDataset(Dataset):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+        self.ds = load_dataset("lambdalabs/pokemon-blip-captions")['train']
+    
+    def __getitem__(self, idx):
+        return self.ds[idx]
+
+    def __len__(self):
+        return len(self.ds)
+
+class DataCollator:
+    def __init__(self, tokenizer, size = 32, target_frames = 100, cfg_prob = 0.1, **kwargs):
+        self.tokenizer = tokenizer
+        self.image_size = size
+        self.target_frames = target_frames
+        self.cfg_prob = cfg_prob
+
+    def __call__(self, batch):
+        images = [d['image'] for d in batch]
+        captions = [d['text'] if random.random() >= self.cfg_prob else "" for d in batch]
+
+        
+        transform = transforms.Compose([
+            transforms.Resize((self.image_size, self.image_size)),
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+            transforms.RandomHorizontalFlip()
+        ])
+        
+        images = [transform(img) for img in images]
+        images = torch.stack(images)
+
+        tokenizer_out = self.tokenizer(captions, return_tensors='pt', padding='max_length', truncation=True, max_length=77)
+        input_ids = tokenizer_out['input_ids']
+        attention_mask = tokenizer_out['attention_mask']
+
+        # Turn the images into mock videos
+        videos = eo.repeat(images, 'b c h w -> b n c h w', n = self.target_frames).contiguous()
+
+        return {
+            "pixel_values" : videos,
+            "input_ids" : input_ids,
+            "attention_mask" : attention_mask,
+            "frame_rates" : torch.tensor([10.0]*len(videos))
+        }
+
+if __name__ == "__main__":
+    from torch.utils.data import DataLoader
+    from transformers import AutoTokenizer
+    tokenizer = AutoTokenizer.from_pretrained("laion/CLIP-ViT-L-14-laion2B-s32B-b82K")
+    ds = VideoDataset()
+    dc = DataCollator(tokenizer)
+
+    loader = DataLoader(ds, collate_fn=dc, batch_size=8, num_workers=0)
+
+    for batch in loader:
+        print("Shape of videos: ", batch["pixel_values"].shape)
+        print("Shape of input_ids: ", batch["input_ids"].shape)
+        print("Frame rates: ", batch["frame_rates"])

--- a/dit_videos/trainer.py
+++ b/dit_videos/trainer.py
@@ -4,7 +4,9 @@ from .inference import wandb_sample
 from .configs import ProjectConfig
 from .denoiser import Denoiser
 from .nn.dit import DiTVideo
-from .data_sd import VideoDataset, DataCollator
+
+#from .data_sd import VideoDataset, DataCollator
+from .pokemon_data import VideoDataset, DataCollator
 
 import wandb
 import torch
@@ -113,7 +115,6 @@ class Trainer:
                 with self.accelerator.accumulate(self.model), self.accelerator.autocast():
                     if batch == "BATCH_ERROR":
                         continue
-                    print(batch["frame_rates"])
 
                     embeds = encode_text(batch)
                     loss = self.model(batch['pixel_values'], embeds)
@@ -138,7 +139,7 @@ class Trainer:
 
                     if idx % self.config.train.sample_every == 0 and self.accelerator.is_main_process:
                         with torch.no_grad():
-                            wandb_videos = wandb_sample(self.accelerator.unwrap_model(self.model), self.config.train.sample_prompts)
+                            wandb_videos = wandb_sample(self.accelerator.unwrap_model(self.model), self.config.train.sample_prompts, mode = "ode")
                             if self.use_wandb:
                                 wandb.log({
                                     "videos" : wandb_videos


### PR DESCRIPTION
Main changes
- Use learned embeddings for each temporal patches (Previous method did a common time-embedding for i-th time patches, now we just have learned embeddings for every patch regardless of dim)
- Rectified flow objective
- Remove variance prediction entirely
- ODE inference